### PR TITLE
Add back in a clap option parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,54 @@
 version = 3
 
 [[package]]
+name = "anstream"
+version = "0.6.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d96bd03f33fe50a863e394ee9718a706f988b9079b20c3784fb726e7678b62fb"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
+dependencies = [
+ "anstyle",
+ "windows-sys",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -19,6 +67,52 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "clap"
+version = "4.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528131438037fd55894f62d6e9f068b8f45ac57ffa77517819645d10aed04f64"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "equivalent"
@@ -47,6 +141,12 @@ name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "id-arena"
@@ -191,6 +291,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "syn"
 version = "2.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -226,10 +332,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
 name = "wasm-component-ld"
 version = "0.1.5"
 dependencies = [
  "anyhow",
+ "clap",
  "lexopt",
  "tempfile",
  "wasmparser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 
 [dependencies]
 anyhow = "1.0.80"
+clap = { version = "4.5.4", features = ['derive'] }
 lexopt = "0.3.0"
 tempfile = "3.10.0"
 wasmparser = "0.202.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,19 +1,149 @@
 use anyhow::{bail, Context, Result};
-use lexopt::{Arg, Parser, ValueExt};
+use clap::{ArgAction, ArgGroup, CommandFactory, FromArgMatches};
+use lexopt::{Arg, ValueExt};
 use std::env;
 use std::ffi::OsString;
 use std::path::PathBuf;
 use std::process::Command;
 use wasmparser::Payload;
 
+struct LldFlag {
+    clap_name: &'static str,
+    long: Option<&'static str>,
+    short: Option<char>,
+    value: Option<&'static str>,
+}
+
+const LLD_FLAGS: &[LldFlag] = &[
+    LldFlag {
+        clap_name: "no-entry",
+        long: Some("no-entry"),
+        short: None,
+        value: None,
+    },
+    LldFlag {
+        clap_name: "no-demangle",
+        long: Some("no-demangle"),
+        short: None,
+        value: None,
+    },
+    LldFlag {
+        clap_name: "allow-undefined",
+        long: Some("allow-undefined"),
+        short: None,
+        value: None,
+    },
+    LldFlag {
+        clap_name: "stack-first",
+        long: Some("stack-first"),
+        short: None,
+        value: None,
+    },
+    LldFlag {
+        clap_name: "gc-sections",
+        long: Some("gc-sections"),
+        short: None,
+        value: None,
+    },
+    LldFlag {
+        clap_name: "whole-archive",
+        long: Some("whole-archive"),
+        short: None,
+        value: None,
+    },
+    LldFlag {
+        clap_name: "no-whole-archive",
+        long: Some("no-whole-archive"),
+        short: None,
+        value: None,
+    },
+    LldFlag {
+        clap_name: "fatal-warnings",
+        long: Some("fatal-warnings"),
+        short: None,
+        value: None,
+    },
+    LldFlag {
+        clap_name: "export",
+        long: Some("export"),
+        short: None,
+        value: Some("SYM"),
+    },
+    LldFlag {
+        clap_name: "entry",
+        long: Some("entry"),
+        short: None,
+        value: Some("SYM"),
+    },
+    LldFlag {
+        clap_name: "lib",
+        long: None,
+        short: Some('l'),
+        value: Some("LIB"),
+    },
+    LldFlag {
+        clap_name: "link-path",
+        long: None,
+        short: Some('L'),
+        value: Some("PATH"),
+    },
+    LldFlag {
+        clap_name: "extra",
+        long: None,
+        short: Some('z'),
+        value: Some("OPT"),
+    },
+    LldFlag {
+        clap_name: "optimize",
+        long: None,
+        short: Some('O'),
+        value: Some("LEVEL"),
+    },
+    LldFlag {
+        clap_name: "arch",
+        long: None,
+        short: Some('m'),
+        value: Some("ARCH"),
+    },
+];
+
+const LLD_LONG_FLAGS_NONSTANDARD: &[&str] = &["-shared"];
+
 #[derive(Default)]
 struct App {
-    output: Option<PathBuf>,
-    rsp_quoting: Option<String>,
-    wasi_proxy_adapter: bool,
-    wasm_ld_path: Option<PathBuf>,
+    component: ComponentLdArgs,
     lld_args: Vec<OsString>,
     shared: bool,
+}
+
+/// A linker to create a Component from input object files and libraries.
+///
+/// This application is an equivalent of `wasm-ld` except that it produces a
+/// component instead of a core wasm module. This application behaves very
+/// similarly to `wasm-ld` in that it takes the same inputs and flags, and it
+/// will internally invoke `wasm-ld`. After `wasm-ld` has been invoked the core
+/// wasm module will be turned into a component using component tooling and
+/// embedded information in the core wasm module.
+#[derive(clap::Parser, Default)]
+struct ComponentLdArgs {
+    /// Instructs the "proxy" adapter to be used for use in a `wasi:http/proxy`
+    /// world.
+    #[clap(long)]
+    wasi_proxy_adapter: bool,
+
+    /// Location of where to find `wasm-ld`.
+    ///
+    /// If not specified this is automatically detected.
+    #[clap(long)]
+    wasm_ld_path: Option<PathBuf>,
+
+    /// Quoting syntax for response files, forwarded to LLD.
+    #[clap(long)]
+    rsp_quoting: Option<String>,
+
+    /// Where to place the component output.
+    #[clap(short)]
+    output: Option<PathBuf>,
 }
 
 fn main() {
@@ -33,57 +163,117 @@ fn main() {
 }
 
 fn run() -> Result<()> {
-    let mut args = env::args_os().collect::<Vec<_>>();
-    if let Some([flavor, wasm]) = args.get(1..3) {
-        if flavor == "-flavor" && wasm == "wasm" {
-            args.remove(1);
-            args.remove(1);
-        }
-    }
-
-    let mut app = App::default();
-    let mut parser = Parser::from_iter(args);
-    loop {
-        if let Some(mut args) = parser.try_raw_args() {
-            if let Some(arg) = args.peek() {
-                if arg == "-shared" {
-                    app.lld_args.push(arg.to_owned());
-                    app.shared = true;
-                    args.next();
-                    continue;
-                }
-            }
-        }
-        match parser.next()? {
-            Some(Arg::Long(
-                s @ ("no-entry" | "no-demangle" | "allow-undefined" | "stack-first" | "gc-sections"
-                | "whole-archive" | "no-whole-archive" | "fatal-warnings"),
-            )) => {
-                app.lld_args.push(format!("--{s}").into());
-            }
-            Some(Arg::Long("rsp-quoting")) => app.rsp_quoting = Some(parser.value()?.parse()?),
-            Some(Arg::Long("wasm-ld-path")) => app.wasm_ld_path = Some(parser.value()?.into()),
-            Some(Arg::Long(s @ ("export" | "entry"))) => {
-                app.lld_args.push(format!("--{s}").into());
-                app.lld_args.push(parser.value()?);
-            }
-            Some(Arg::Short(c @ ('L' | 'z' | 'l' | 'O' | 'm'))) => {
-                app.lld_args.push(format!("-{c}").into());
-                app.lld_args.push(parser.value()?);
-            }
-            Some(Arg::Short('o')) => app.output = Some(parser.value()?.into()),
-            Some(Arg::Value(obj)) => app.lld_args.push(obj),
-            Some(other) => bail!(other.unexpected()),
-            None => break,
-        }
-    }
-    if app.output.is_none() {
-        bail!("must specify an output path via `-o`");
-    }
-    app.run()
+    App::parse()?.run()
 }
 
 impl App {
+    /// Parse the CLI arguments into an `App` to run the linker.
+    ///
+    /// This is unfortunately nontrivial because the way `wasm-ld` takes
+    /// arguments is not compatible with `clap`. Namely flags like
+    /// `--whole-archive` are positional are processed in a stateful manner.
+    /// This means that the relative ordering of flags to `wasm-ld` needs to be
+    /// preserved. Additionally there are flags like `-shared` which clap does
+    /// not support.
+    ///
+    /// To handle this the `lexopt` crate is used to perform low-level argument
+    /// parsing. That's then used to determine whether the argument is intended
+    /// for `wasm-component-ld` or `wasm-ld`, so arguments are filtered into two
+    /// lists. Using these lists the arguments to `wasm-component-ld` are then
+    /// parsed. On failure a help message is presented with all `wasm-ld`
+    /// arguments added as well.
+    ///
+    /// This means that functionally it looks like `clap` parses everything when
+    /// in fact `lexopt` is used to filter out `wasm-ld` arguments and `clap`
+    /// only parses arguments specific to `wasm-component-ld`.
+    fn parse() -> Result<App> {
+        let mut args = env::args_os().collect::<Vec<_>>();
+
+        // First remove `-flavor wasm` in case this is invoked as a generic LLD
+        // driver. We can safely ignore that going forward.
+        if let Some([flavor, wasm]) = args.get(1..3) {
+            if flavor == "-flavor" && wasm == "wasm" {
+                args.remove(1);
+                args.remove(1);
+            }
+        }
+
+        let mut command = ComponentLdArgs::command();
+        let mut lld_args = Vec::new();
+        let mut component_ld_args = vec![std::env::args_os().nth(0).unwrap()];
+        let mut shared = false;
+        let mut parser = lexopt::Parser::from_iter(args);
+        loop {
+            if let Some(mut args) = parser.try_raw_args() {
+                if let Some(arg) = args.peek() {
+                    let for_lld = LLD_LONG_FLAGS_NONSTANDARD.iter().any(|s| arg == *s);
+                    if for_lld {
+                        lld_args.push(arg.to_owned());
+                        if arg == "-shared" {
+                            shared = true;
+                        }
+                        args.next();
+                        continue;
+                    }
+                }
+            }
+
+            match parser.next()? {
+                Some(Arg::Value(obj)) => {
+                    lld_args.push(obj);
+                }
+                Some(Arg::Short(c)) => match LLD_FLAGS.iter().find(|f| f.short == Some(c)) {
+                    Some(lld) => {
+                        lld_args.push(format!("-{c}").into());
+                        if lld.value.is_some() {
+                            lld_args.push(parser.value()?);
+                        }
+                    }
+                    None => {
+                        component_ld_args.push(format!("-{c}").into());
+                        if let Some(arg) =
+                            command.get_arguments().find(|a| a.get_short() == Some(c))
+                        {
+                            if let ArgAction::Set = arg.get_action() {
+                                component_ld_args.push(parser.value()?);
+                            }
+                        }
+                    }
+                },
+                Some(Arg::Long(c)) => match LLD_FLAGS.iter().find(|f| f.long == Some(c)) {
+                    Some(lld) => {
+                        lld_args.push(format!("--{c}").into());
+                        if lld.value.is_some() {
+                            lld_args.push(parser.value()?);
+                        }
+                    }
+                    None => {
+                        component_ld_args.push(format!("--{c}").into());
+                        if let Some(arg) = command.get_arguments().find(|a| a.get_long() == Some(c))
+                        {
+                            if let ArgAction::Set = arg.get_action() {
+                                component_ld_args.push(parser.value()?);
+                            }
+                        }
+                    }
+                },
+                None => break,
+            }
+        }
+
+        match command.try_get_matches_from_mut(component_ld_args.clone()) {
+            Ok(matches) => Ok(App {
+                component: ComponentLdArgs::from_arg_matches(&matches)?,
+                lld_args,
+                shared,
+            }),
+            Err(_) => {
+                add_wasm_ld_options(ComponentLdArgs::command()).get_matches_from(component_ld_args);
+                unreachable!();
+            }
+        }
+    }
+
     fn run(&mut self) -> Result<()> {
         let mut cmd = self.lld();
         let linker = cmd.get_program().to_owned();
@@ -96,7 +286,7 @@ impl App {
         // temporary location for wit-component to read and then the real output
         // is created after wit-component runs.
         if self.shared {
-            cmd.arg("-o").arg(self.output.as_ref().unwrap());
+            cmd.arg("-o").arg(self.component.output.as_ref().unwrap());
         } else {
             cmd.arg("-o").arg(lld_output.path());
         }
@@ -140,7 +330,7 @@ impl App {
 
         let adapter = if exports_start {
             &command_adapter[..]
-        } else if self.wasi_proxy_adapter {
+        } else if self.component.wasi_proxy_adapter {
             &proxy_adapter[..]
         } else {
             &reactor_adapter[..]
@@ -154,7 +344,7 @@ impl App {
             .encode()
             .context("failed to encode component")?;
 
-        std::fs::write(self.output.as_ref().unwrap(), &component)
+        std::fs::write(self.component.output.as_ref().unwrap(), &component)
             .context("failed to write output file")?;
 
         Ok(())
@@ -167,7 +357,7 @@ impl App {
     }
 
     fn find_lld(&self) -> Command {
-        if let Some(path) = &self.wasm_ld_path {
+        if let Some(path) = &self.component.wasm_ld_path {
             return Command::new(path);
         }
 
@@ -190,4 +380,33 @@ impl App {
         // be found.
         Command::new("wasm-ld")
     }
+}
+
+fn add_wasm_ld_options(mut command: clap::Command) -> clap::Command {
+    use clap::Arg;
+
+    command = command.arg(
+        Arg::new("objects")
+            .action(ArgAction::Append)
+            .help("objects to pass to `wasm-ld`"),
+    );
+
+    for flag in LLD_FLAGS {
+        let mut arg = Arg::new(flag.clap_name).help("forwarded to `wasm-ld`");
+        if let Some(short) = flag.short {
+            arg = arg.short(short);
+        }
+        if let Some(long) = flag.long {
+            arg = arg.long(long);
+        }
+        arg = arg.action(if flag.value.is_some() {
+            ArgAction::Set
+        } else {
+            ArgAction::SetTrue
+        });
+        arg = arg.help_heading("Options forwarded to `wasm-ld`");
+        command = command.arg(arg);
+    }
+
+    command
 }


### PR DESCRIPTION
Do some various tricks to preserve the argument order passed to LLD, however, by continuing to use `lexopt` to segment arguments.

Closes #2